### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -1,0 +1,28 @@
+name: Docker Smoke Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - prod
+
+jobs:
+  docker-build:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          # Use a dummy year value; the build arg is only cosmetic in the UI
+          build-args: REACT_APP_PHUX_YEAR=2024
+          # Keep the image in the build cache but don't export it
+          outputs: type=cacheonly

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   backend-lint:
-    name: Backend – type check & lint
+    name: Backend - type check & lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
         run: yarn lint
 
   frontend-typecheck:
-    name: Frontend – type check
+    name: Frontend - type check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -1,0 +1,55 @@
+name: Lint & Type Check
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - prod
+
+jobs:
+  backend-lint:
+    name: Backend – type check & lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Enable Corepack (Yarn 4)
+        run: corepack enable && corepack prepare yarn@4.13.0 --activate
+
+      - name: Install dependencies
+        working-directory: back
+        run: yarn install --immutable
+
+      - name: Type check
+        working-directory: back
+        run: yarn typecheck
+
+      - name: Lint
+        working-directory: back
+        run: yarn lint
+
+  frontend-typecheck:
+    name: Frontend – type check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Enable Corepack (Yarn 4)
+        run: corepack enable && corepack prepare yarn@4.13.0 --activate
+
+      - name: Install dependencies
+        working-directory: front
+        run: yarn install --immutable
+
+      - name: Type check
+        working-directory: front
+        run: yarn typecheck

--- a/back/package.json
+++ b/back/package.json
@@ -7,6 +7,8 @@
     "test": "cross-env NODE_ENV=test jest --verbose --runInBand --detectOpenHandles --watch",
     "start:test": "cross-env NODE_ENV=test node index.ts",
     "build-ts": "tsc --build tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "lint": "tslint -c tslint.json -p tsconfig.json",
     "start": "yarn run serve",
     "serve": "node dist/index.js",
     "dev": "NODE_ENV=development ts-node-dev src/index.ts"

--- a/front/package.json
+++ b/front/package.json
@@ -33,7 +33,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "typecheck": "tsc --noEmit"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
## Add CI workflows

Adds two GitHub Actions workflows that run on every PR and push to `main`/`prod`.

### `ci-lint.yml` – Lint & Type Check
- **Backend**: `tsc --noEmit` (type errors) + `tslint` (code style) in `back/`
- **Frontend**: `tsc --noEmit` (type errors) in `front/`

### `ci-docker.yml` – Docker Smoke Test
- Builds the full multi-stage Docker image to verify the build succeeds end-to-end
- Does not push the image (no registry credentials needed on PRs)

### Supporting changes
- `back/package.json`: added `typecheck` and `lint` scripts
- `front/package.json`: added `typecheck` script

---

> **To enforce these as merge blockers**, go to **Settings → Branches → Branch protection rules** for `main`/`prod`, enable *"Require status checks to pass"*, and add the three job names:
> - `Backend – type check & lint`
> - `Frontend – type check`
> - `Build Docker image`